### PR TITLE
Add RegexpHandler

### DIFF
--- a/regexp_handler.go
+++ b/regexp_handler.go
@@ -1,0 +1,75 @@
+package conductor
+
+import (
+	"errors"
+	"net/http"
+	"regexp"
+)
+
+// A RegexpRoute defines the Handler for a regular expression Pattern
+type RegexpRoute struct {
+	Pattern *regexp.Regexp
+	Handler http.HandlerFunc
+}
+
+// NewRegexpRoute returns a RegexpRoute for a pattern to a handler
+func NewRegexpRoute(pattern string, handler http.HandlerFunc) (*RegexpRoute, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return &RegexpRoute{re, handler}, nil
+}
+
+// A RegexpRouteMap associates HTTP methods to slices of RegexpRoutes
+//
+// Example:
+//	routes := RegexpRouteMap{}
+//	routes.AddRoute(http.MethodGet, RegexpRoute{`/posts[/]?$`, handleGetAllPosts})
+//	routes.AddRoute(http.MethodGet, RegexpRoute{`/posts/[0-9]+$`, handleGetPost})
+type RegexpRouteMap map[string][]*RegexpRoute
+
+// AddRoute attaches route to map for http method
+func (m RegexpRouteMap) AddRoute(method, pattern string, handler http.HandlerFunc) error {
+	route, err := NewRegexpRoute(pattern, handler)
+	if err != nil {
+		return err
+	}
+
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodConnect, http.MethodOptions, http.MethodTrace:
+		m[method] = append(m[method], route)
+	default:
+		return errors.New("invalid HTTP method")
+	}
+
+	return nil
+}
+
+type regexpHandler struct {
+	routes RegexpRouteMap
+}
+
+func (rh *regexpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var err error
+
+	// Find routes for HTTP method
+	routes, ok := rh.routes[r.Method]
+
+	if ok {
+		for _, route := range routes {
+			if route.Pattern.MatchString(r.URL.Path) {
+				route.Handler(w, r)
+				return
+			}
+		}
+	}
+
+	// No matching route found
+	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+}
+
+// RegexpHandler returns a request handler that
+func RegexpHandler(routes RegexpRouteMap) http.Handler {
+	return &regexpHandler{routes}
+}

--- a/regexp_handler.go
+++ b/regexp_handler.go
@@ -51,22 +51,21 @@ type regexpHandler struct {
 }
 
 func (rh *regexpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	var err error
-
 	// Find routes for HTTP method
 	routes, ok := rh.routes[r.Method]
+	if !ok {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
 
-	if ok {
-		for _, route := range routes {
-			if route.Pattern.MatchString(r.URL.Path) {
-				route.Handler(w, r)
-				return
-			}
+	for _, route := range routes {
+		if route.Pattern.MatchString(r.URL.Path) {
+			route.Handler(w, r)
+			return
 		}
 	}
 
 	// No matching route found
-	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 }
 
 // RegexpHandler returns a request handler that

--- a/regexp_handler_test.go
+++ b/regexp_handler_test.go
@@ -1,0 +1,78 @@
+package conductor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestRegexpHandler(t *testing.T) {
+	testcases := []struct {
+		Method string
+		Path   string
+		Body   url.Values
+		Status int
+	}{
+		{
+			Method: http.MethodGet,
+			Path:   "/posts",
+			Status: http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "/posts/1",
+			Status: http.StatusOK,
+		},
+		{
+			Method: http.MethodPost,
+			Path:   "/posts",
+			Body: url.Values{
+				"title": {"sample post"},
+				"body":  {"post body"},
+			},
+			Status: http.StatusOK,
+		},
+		{
+			Method: http.MethodPut,
+			Path:   "/posts/1",
+			Body: url.Values{
+				"body": {"updated post body"},
+			},
+			Status: http.StatusOK,
+		},
+		{
+			Method: http.MethodDelete,
+			Path:   "/posts/1",
+			Status: http.StatusOK,
+		},
+		{
+			Method: http.MethodGet,
+			Path:   "posts/23/comments",
+			Status: http.StatusNotFound,
+		},
+	}
+
+	// Create RESTful /posts resource
+	routes := RegexpRouteMap{}
+	routes.AddRoute(http.MethodGet, `/posts[/]?$`, indexHandler)
+	routes.AddRoute(http.MethodGet, `/posts/[0-9]+$`, showHandler)
+	routes.AddRoute(http.MethodPost, `/posts[/]?$`, createHandler)
+	routes.AddRoute(http.MethodPut, `/posts/[0-9]+$`, updateHandler)
+	routes.AddRoute(http.MethodDelete, `/posts/[0-9]+$`, destroyHandler)
+	handler := RegexpHandler(routes)
+
+	for _, tc := range testcases {
+		req, err := http.NewRequest(tc.Method, tc.Path, tc.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if status := w.Code; status != tc.Status {
+			t.Errorf("handler status code %v, expected %v", status, tc.Status)
+		}
+	}
+}

--- a/regexp_handler_test.go
+++ b/regexp_handler_test.go
@@ -3,8 +3,6 @@ package conductor
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"html"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,22 +10,30 @@ import (
 	"testing"
 )
 
+type testResponse struct {
+	Path    string
+	Matches []string
+}
+
 func TestRegexpHandler(t *testing.T) {
 	testcases := []struct {
-		Method string
-		Path   string
-		Body   url.Values
-		Status int
+		Method  string
+		Path    string
+		Body    url.Values
+		Status  int
+		Matches []string
 	}{
 		{
-			Method: http.MethodGet,
-			Path:   "/posts",
-			Status: http.StatusOK,
+			Method:  http.MethodGet,
+			Path:    "/posts",
+			Status:  http.StatusOK,
+			Matches: []string{"/posts"},
 		},
 		{
-			Method: http.MethodGet,
-			Path:   "/posts/1",
-			Status: http.StatusOK,
+			Method:  http.MethodGet,
+			Path:    "/posts/1",
+			Status:  http.StatusOK,
+			Matches: []string{"/posts/1", "1"},
 		},
 		{
 			Method: http.MethodPost,
@@ -36,7 +42,8 @@ func TestRegexpHandler(t *testing.T) {
 				"title": {"sample post"},
 				"body":  {"post body"},
 			},
-			Status: http.StatusOK,
+			Status:  http.StatusOK,
+			Matches: []string{"/posts"},
 		},
 		{
 			Method: http.MethodPut,
@@ -44,12 +51,14 @@ func TestRegexpHandler(t *testing.T) {
 			Body: url.Values{
 				"body": {"updated post body"},
 			},
-			Status: http.StatusOK,
+			Status:  http.StatusOK,
+			Matches: []string{"/posts/1", "1"},
 		},
 		{
-			Method: http.MethodDelete,
-			Path:   "/posts/1",
-			Status: http.StatusOK,
+			Method:  http.MethodDelete,
+			Path:    "/posts/1",
+			Status:  http.StatusOK,
+			Matches: []string{"/posts/1", "1"},
 		},
 		{
 			Method: http.MethodGet,
@@ -58,17 +67,29 @@ func TestRegexpHandler(t *testing.T) {
 		},
 	}
 
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, html.EscapeString(r.URL.Path))
-	})
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		response := testResponse{Path: r.URL.Path}
+
+		matches, ok := RegexpMatchesFromContext(r.Context())
+		if ok {
+			response.Matches = matches
+		}
+
+		output, err := json.Marshal(response)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(output)
+	}
 
 	// Create RESTful /posts resource
 	routes := RegexpRouteMap{}
-	routes.AddRoute(http.MethodGet, `/posts[/]?$`, handler)
-	routes.AddRoute(http.MethodGet, `/posts/[0-9]+$`, handler)
-	routes.AddRoute(http.MethodPost, `/posts[/]?$`, handler)
-	routes.AddRoute(http.MethodPut, `/posts/[0-9]+$`, handler)
-	routes.AddRoute(http.MethodDelete, `/posts/[0-9]+$`, handler)
+	routes.AddRouteFunc(http.MethodGet, `/posts[/]?$`, handler)
+	routes.AddRouteFunc(http.MethodGet, `/posts/([0-9]+)$`, handler)
+	routes.AddRouteFunc(http.MethodPost, `/posts[/]?$`, handler)
+	routes.AddRouteFunc(http.MethodPut, `/posts/([0-9]+)$`, handler)
+	routes.AddRouteFunc(http.MethodDelete, `/posts/([0-9]+)$`, handler)
 	rh := RegexpHandler(routes)
 
 	for _, tc := range testcases {
@@ -84,21 +105,36 @@ func TestRegexpHandler(t *testing.T) {
 		w := httptest.NewRecorder()
 		rh.ServeHTTP(w, req)
 
-		data := strings.TrimSpace(w.Body.String())
 		status := w.Code
-
 		if status != tc.Status {
 			t.Errorf("handler status code %v, expected %v", status, tc.Status)
 		}
 
 		switch status {
 		default:
+			data := strings.TrimSpace(w.Body.String())
 			if data != http.StatusText(tc.Status) {
 				t.Errorf("handler error %s, expected %s", data, http.StatusText(tc.Status))
 			}
 		case http.StatusOK:
-			if data != tc.Path {
-				t.Errorf("handler path %s, expected %s", data, tc.Path)
+			var data testResponse
+			err := json.Unmarshal(w.Body.Bytes(), &data)
+			if err != nil {
+				t.Fatalf("%v: %s", err, w.Body.String())
+			}
+
+			if data.Path != tc.Path {
+				t.Errorf("handler path %s, expected %s", data.Path, tc.Path)
+			}
+
+			if len(data.Matches) != len(tc.Matches) {
+				t.Errorf("handler regexp matches %+v, expected %+v", data.Matches, tc.Matches)
+			} else {
+				for i := 0; i < len(data.Matches); i++ {
+					if data.Matches[i] != tc.Matches[i] {
+						t.Errorf("handler match %v, expected %v", data.Matches[i], tc.Matches[i])
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Defines Regular Expression handler that maps routes, HTTP method, and pattern to handlers.
Pattern submatches are returned in the context object for the request.