### PR TITLE
Add RouteHandler

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -449,3 +449,71 @@ func TestParameterizedRoutes(t *testing.T) {
 		})
 	}
 }
+
+func TestRouteMap(t *testing.T) {
+	testcases := []testCase{
+		{
+			Path:    "/posts",
+			Method:  http.MethodGet,
+			Status:  http.StatusOK,
+			Matches: map[string]string{},
+		},
+		{
+			Path:    "/posts/1",
+			Method:  http.MethodGet,
+			Status:  http.StatusOK,
+			Matches: map[string]string{"$1": "1"},
+		},
+		{
+			Path:    "/posts",
+			Method:  http.MethodPost,
+			Status:  http.StatusOK,
+			Matches: map[string]string{},
+			Body: url.Values{
+				"title": {"sample post"},
+				"body":  {"post body"},
+			},
+		},
+		{
+			Path:    "/posts/1",
+			Method:  http.MethodPut,
+			Status:  http.StatusOK,
+			Matches: map[string]string{"$1": "1"},
+			Body: url.Values{
+				"body": {"updated post body"},
+			},
+		},
+		{
+			Path:    "/posts/1",
+			Method:  http.MethodDelete,
+			Status:  http.StatusOK,
+			Matches: map[string]string{"$1": "1"},
+		},
+		{
+			Path:    "/posts/23/comments",
+			Method:  http.MethodGet,
+			Status:  http.StatusOK,
+			Matches: map[string]string{"$1": "23"},
+		},
+		{
+			Path:   "/posts/23/foo",
+			Method: http.MethodGet,
+			Status: http.StatusNotFound,
+		},
+	}
+
+	h := NewRouteHandler()
+	h.HandleRouteFunc(http.MethodGet, `/posts[/]?$`, testHandler)
+	h.HandleRouteFunc(http.MethodGet, `/posts/([0-9]+)$`, testHandler)
+	h.HandleRouteFunc(http.MethodPost, `/posts[/]?$`, testHandler)
+	h.HandleRouteFunc(http.MethodPut, `/posts/([0-9]+)$`, testHandler)
+	h.HandleRouteFunc(http.MethodDelete, `/posts/([0-9]+)$`, testHandler)
+	h.HandleRouteFunc(http.MethodGet, `/posts/([0-9]+)/comments$`, testHandler)
+
+	for _, tc := range testcases {
+		t.Run(tc.String(), func(t *testing.T) {
+			tc := tc
+			tc.Run(t, h)
+		})
+	}
+}


### PR DESCRIPTION
RouteHandler maps HTTP methods to patterns. It is useful for mapping a heterogenous mix of methods and path patterns.